### PR TITLE
Improve API docs

### DIFF
--- a/backend/mj/api.py
+++ b/backend/mj/api.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from fastapi_camelcase import CamelModel
 from fastapi.middleware.cors import CORSMiddleware
 from playhouse.shortcuts import model_to_dict
@@ -36,9 +36,12 @@ class EventsResponse(CamelModel):
 
 @app.get('/events', response_model=EventsResponse)
 def events(
-        min_date: Optional[datetime.date] = None,
-        max_date: Optional[datetime.date] = None,
-        page: int = 1, limit: int = 50):
+        min_date: Optional[datetime.date] = Query(
+            None, alias="minDate", description="Earliest start date"),
+        max_date: Optional[datetime.date] = Query(
+            None, alias="maxDate", description="Latest start date"),
+        page: int = Query(1, description="Page number"),
+        limit: int = Query(50, description="Results per page")):
     events = Event.select().order_by(Event.start_date, Event.start_time)
     if min_date:
         events = events.where(Event.start_date >= min_date)

--- a/backend/mj/api.py
+++ b/backend/mj/api.py
@@ -1,11 +1,13 @@
 import datetime
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI
+from fastapi_camelcase import CamelModel
 from fastapi.middleware.cors import CORSMiddleware
 from playhouse.shortcuts import model_to_dict
 
 import mj
+from mj import schema
 from mj.db import Event
 
 
@@ -19,12 +21,20 @@ app.add_middleware(
 )
 
 
-@app.get('/')
+class RootResponse(CamelModel):
+    version: str
+
+
+@app.get('/', response_model=RootResponse)
 def root():
     return {'version': f'mj-{mj.__version__}'}
 
 
-@app.get('/events')
+class EventsResponse(CamelModel):
+    events: List[schema.Event]
+
+
+@app.get('/events', response_model=EventsResponse)
 def events(
         min_date: Optional[datetime.date] = None,
         max_date: Optional[datetime.date] = None,

--- a/backend/mj/schema.py
+++ b/backend/mj/schema.py
@@ -1,0 +1,40 @@
+import datetime
+from typing import Optional
+
+from fastapi_camelcase import CamelModel
+
+
+class Location(CamelModel):
+    id: int
+    description: str
+
+
+class Organizer(CamelModel):
+    id: int
+    name: str
+
+
+class EventSource(CamelModel):
+    id: int
+    name: str
+
+
+class Event(CamelModel):
+    id: int
+
+    source: EventSource
+    source_event_id: str
+    source_url: Optional[str] = None
+    source_license: Optional[str] = None
+
+    name: str
+    description: str
+    url: Optional[str] = None
+    start_date: datetime.date
+    start_time: Optional[datetime.time] = None
+    end_date: Optional[datetime.date] = None
+    end_time: Optional[datetime.time] = None
+    location: Location
+    performer: Optional[str] = None
+    mode: Optional[str] = None
+    organizer: Optional[Organizer] = None

--- a/backend/mj/schema.py
+++ b/backend/mj/schema.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Optional
 
 from fastapi_camelcase import CamelModel
+from pydantic import Field
 
 
 class Location(CamelModel):
@@ -22,18 +23,24 @@ class EventSource(CamelModel):
 class Event(CamelModel):
     id: int
 
-    source: EventSource
-    source_event_id: str
-    source_url: Optional[str] = None
-    source_license: Optional[str] = None
+    source: EventSource = Field(
+        description='Web source from which event was scraped')
+    source_event_id: str = Field(
+        title="Source Event ID", description="Event ID used at source")
+    source_url: Optional[str] = Field(
+        None, title="Source URL", description="Event details URL at source")
+    source_license: Optional[str] = Field(
+        None,
+        title="Source License",
+        description="License under which source published event data")
 
     name: str
     description: str
-    url: Optional[str] = None
-    start_date: datetime.date
-    start_time: Optional[datetime.time] = None
-    end_date: Optional[datetime.date] = None
-    end_time: Optional[datetime.time] = None
+    url: Optional[str] = Field(None, title="URL")
+    start_date: datetime.date = Field(title="Start Date")
+    start_time: Optional[datetime.time] = Field(None, title="Start Time")
+    end_date: Optional[datetime.date] = Field(None, title="End Date")
+    end_time: Optional[datetime.time] = Field(None, title="End Time")
     location: Location
     performer: Optional[str] = None
     mode: Optional[str] = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ click==7.1.2              # via mj (setup.py), uvicorn
 constantly==15.1.0        # via twisted
 cryptography==3.0         # via pyopenssl, scrapy, service-identity
 cssselect==1.1.0          # via parsel, scrapy
+fastapi-camelcase==1.0.2  # via mj (setup.py)
 fastapi==0.60.1           # via mj (setup.py)
 h11==0.9.0                # via uvicorn
 httptools==0.1.1          # via uvicorn
@@ -28,9 +29,10 @@ psycopg2-binary==2.8.5    # via mj (setup.py)
 pyasn1-modules==0.2.8     # via service-identity
 pyasn1==0.4.8             # via pyasn1-modules, service-identity
 pycparser==2.20           # via cffi
-pydantic==1.6.1           # via fastapi
+pydantic==1.6.1           # via fastapi, fastapi-camelcase
 pydispatcher==2.0.5       # via scrapy
 pyhamcrest==2.0.2         # via twisted
+pyhumps==1.6.1            # via fastapi-camelcase
 pyopenssl==19.1.0         # via scrapy
 queuelib==1.5.0           # via scrapy
 requests==2.24.0          # via mj (setup.py)

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'click',
         'fastapi',
+        'fastapi-camelcase',
         'peewee',
         'psycopg2-binary',
         'requests',


### PR DESCRIPTION
- Add response model definition to OpenAPI spec
- Change all API parameters and response field names to camelCase (:warning: @ubergesundheit **breaking change**)
- Add parameter descriptions

Schemas are currently *not* auto-generated from peewee as that is quite complex and I'll investigate dropping peewee in #108.

Closes #80, closes #109, closes #107.