### PR TITLE
Convert qr url generation to hook

### DIFF
--- a/frontend/src/Kiosk/Kiosk.tsx
+++ b/frontend/src/Kiosk/Kiosk.tsx
@@ -1,21 +1,21 @@
 import React, { FC, useMemo } from "react";
 import KioskLayout from "../UI/KioskLayout/KioskLayout";
 import FullScreenCarousel from "../UI/FullScreenCarousel/FullScreenCarousel";
-import useQuery from "../hooks/useQuery";
+import useDevice from "../hooks/useDevice";
 
 import { mockData, msDisplay1 } from "./mockdata";
 
 const useMockData = () => {
-  const query = useQuery();
+  const device = useDevice();
 
   return useMemo(() => {
-    switch (query?.device) {
+    switch (device) {
       case "ms-display1":
         return msDisplay1;
       default:
         return mockData;
     }
-  }, [query]);
+  }, [device]);
 };
 
 const Kiosk: FC = () => {

--- a/frontend/src/UI/FullScreenCarousel/Slide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/Slide.tsx
@@ -1,19 +1,26 @@
-import React, { FC } from "react";
+import React, { FC, useMemo } from "react";
 import { QRCode } from "react-qr-svg";
-import useQuery from "../../hooks/useQuery";
-
 import styles from "./Slide.module.css";
+import useDevice from "../../hooks/useDevice";
 
-const buildUrl = (
-  externalUrl: string,
-  query: Record<string, string | boolean> | null
-): string => {
-  let url = `${window.location.origin}/qr/`;
-  if (query != null && query.device) {
-    url += `${query.device}/`;
-  }
-  url += `?url=${encodeURI(externalUrl)}`;
-  return url;
+const useQRURL: (externalUrl?: string) => string = (externalUrl) => {
+  const device = useDevice();
+
+  return useMemo(() => {
+    if (!externalUrl) {
+      return "";
+    }
+
+    let url = `${window.location.origin}/qr/`;
+
+    if (device) {
+      url += `${device}/`;
+    }
+
+    url += `?url=${encodeURI(externalUrl)}`;
+
+    return url;
+  }, [device, externalUrl]);
 };
 
 const convertCssClass = function convertCssClass(
@@ -37,7 +44,8 @@ const Slide: FC<IEvent> = ({
   style,
   cssClassNames,
 }) => {
-  const query = useQuery();
+  const qrUrl = useQRURL(externalUrl);
+
   return (
     <div className={convertCssClass(cssClassNames)} style={style}>
       <div className={styles.slideContainer}>
@@ -52,10 +60,7 @@ const Slide: FC<IEvent> = ({
           )}
           {externalUrl && (
             <div className={styles.qrContainer}>
-              <QRCode
-                value={buildUrl(externalUrl, query)}
-                className={styles.qr}
-              />
+              <QRCode value={qrUrl} className={styles.qr} />
             </div>
           )}
         </div>

--- a/frontend/src/hooks/useDevice.ts
+++ b/frontend/src/hooks/useDevice.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import useQuery from "./useQuery";
+
+const useDevice: () => string | null = () => {
+  const query = useQuery();
+
+  return useMemo(() => {
+    if (query?.device) {
+      return query.device as string;
+    }
+
+    return null;
+  }, [query]);
+};
+
+export default useDevice;


### PR DESCRIPTION
This PR adds a new `useDevice` hook to easily get the `device` parameter from the query and also introduces an `useQRURL` hook which memoizes the qr url for slides.

Related to https://github.com/codeformuenster/muenster-jetzt/pull/178#discussion_r483921894

FYI @bCyberBasti 