### PR TITLE
change handling of env variables for postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This guide will help you to setup everything in a convenient way without the typ
 ### Pre-Requirements
 Install the following things:
 * [Docker](https://www.docker.com/)
-* [Docker-Compose](https://docs.docker.com/compose/)
+* [Docker-Compose](https://docs.docker.com/compose/), version 1.26.2 or greater
 * [Visual Studio Code](https://code.visualstudio.com/)
 * [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,8 @@ DB_NAME=muenster-jetzt-dev
 DB_HOST=localhost
 DB_PORT=5432
 MUENSTERLAND_API_TOKEN=01234567890abcdef0123456789abcdef
+
+# do not customize values from here on
+POSTGRES_USER=${DB_USER}
+POSTGRES_PASSWORD=${DB_PASSWORD}
+POSTGRES_DB=${DB_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,3 @@ services:
     ports:
       - 5432:5432
     env_file: ./backend/.env
-    environment:
-      POSTGRES_USER: "${DB_USER}"
-      POSTGRES_PASSWORD: "${DB_PASSWORD}"
-      POSTGRES_DB: "${DB_NAME}"


### PR DESCRIPTION
@ubergesundheit 
might this be a useful update of how environmental variables are read?

with this change, you might be able to replace your current "`export $(cat backend/.env | xargs) && docker-compose up -d db`"
with a simpler "`docker-compose up -d db`".
