### PR TITLE
Pause autoplay & manually forward slide after video end

### DIFF
--- a/frontend/src/UI/FullScreenCarousel/FullScreenCarousel.tsx
+++ b/frontend/src/UI/FullScreenCarousel/FullScreenCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import clsx from "clsx";
 import SwiperCore, { Autoplay, Navigation } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -22,6 +22,7 @@ const FullScreenCarousel: FC<IFullScreenCarousel> = ({ slides }) => {
     sendRequest: sendTrackingRequest,
     onSlide: onSlideTracking,
   } = useKioskTracking();
+  const [swiperInstance, setSwiperInstance] = useState<SwiperCore | null>(null);
 
   const { startAutoplayResume, stopAutoplayResume } = useAutoplayResume(30000);
 
@@ -46,6 +47,9 @@ const FullScreenCarousel: FC<IFullScreenCarousel> = ({ slides }) => {
         stopAutoplayResume();
       }}
       allowTouchMove={false}
+      onSwiper={(swiper) => {
+        setSwiperInstance(swiper);
+      }}
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div
@@ -59,7 +63,11 @@ const FullScreenCarousel: FC<IFullScreenCarousel> = ({ slides }) => {
       {slides.map((slide) => (
         <SwiperSlide key={slide.id} data-kiosk-slide-id={slide.id}>
           {({ isActive }: { isActive: boolean }) => (
-            <Slide {...slide} playing={isActive} />
+            <Slide
+              {...slide}
+              playing={isActive}
+              swiperInstance={swiperInstance}
+            />
           )}
         </SwiperSlide>
       ))}

--- a/frontend/src/UI/FullScreenCarousel/FullScreenCarousel.tsx
+++ b/frontend/src/UI/FullScreenCarousel/FullScreenCarousel.tsx
@@ -67,6 +67,7 @@ const FullScreenCarousel: FC<IFullScreenCarousel> = ({ slides }) => {
               {...slide}
               playing={isActive}
               swiperInstance={swiperInstance}
+              stopAutoplayResume={stopAutoplayResume}
             />
           )}
         </SwiperSlide>

--- a/frontend/src/UI/FullScreenCarousel/Slide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/Slide.tsx
@@ -1,14 +1,16 @@
-import React, { FC, useEffect, useMemo } from "react";
+import React, { FC, useMemo } from "react";
 import { QRCode } from "react-qr-svg";
 import SwiperCore from "swiper";
 import styles from "./Slide.module.css";
 import useDevice from "../../hooks/useDevice";
 import IFrameSlide from "./IFrameSlide";
 import VideoSlide from "./VideoSlide";
+import { IStopAutoplayResume } from "../../hooks/useAutoplayResume";
 
 interface ISlideComponent extends ISlide {
   playing: boolean;
   swiperInstance: SwiperCore | null;
+  stopAutoplayResume: IStopAutoplayResume;
 }
 
 const useQRURL: (externalUrl?: string) => string = (externalUrl) => {
@@ -55,14 +57,9 @@ const Slide: FC<ISlideComponent> = ({
   video,
   playing,
   swiperInstance,
+  stopAutoplayResume,
 }) => {
   const qrUrl = useQRURL(externalUrl);
-
-  useEffect(() => {
-    if (playing) {
-      swiperInstance?.autoplay?.stop();
-    }
-  }, [playing, swiperInstance]);
 
   return (
     <div className={convertCssClass(cssClassNames)} style={style}>
@@ -74,10 +71,8 @@ const Slide: FC<ISlideComponent> = ({
               <VideoSlide
                 video={video}
                 playing={playing}
-                onVideoEnd={() => {
-                  swiperInstance?.slideNext();
-                  swiperInstance?.autoplay?.start();
-                }}
+                swiperInstance={swiperInstance}
+                stopAutoplayResume={stopAutoplayResume}
               />
             )}
           </>

--- a/frontend/src/UI/FullScreenCarousel/Slide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/Slide.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useMemo } from "react";
+import React, { FC, useEffect, useMemo } from "react";
 import { QRCode } from "react-qr-svg";
+import SwiperCore from "swiper";
 import styles from "./Slide.module.css";
 import useDevice from "../../hooks/useDevice";
 import IFrameSlide from "./IFrameSlide";
@@ -7,6 +8,7 @@ import VideoSlide from "./VideoSlide";
 
 interface ISlideComponent extends ISlide {
   playing: boolean;
+  swiperInstance: SwiperCore | null;
 }
 
 const useQRURL: (externalUrl?: string) => string = (externalUrl) => {
@@ -52,8 +54,15 @@ const Slide: FC<ISlideComponent> = ({
   iFrame,
   video,
   playing,
+  swiperInstance,
 }) => {
   const qrUrl = useQRURL(externalUrl);
+
+  useEffect(() => {
+    if (playing) {
+      swiperInstance?.autoplay?.stop();
+    }
+  }, [playing, swiperInstance]);
 
   return (
     <div className={convertCssClass(cssClassNames)} style={style}>
@@ -61,7 +70,16 @@ const Slide: FC<ISlideComponent> = ({
         {iFrame || video ? (
           <>
             {iFrame?.url && <IFrameSlide iFrame={iFrame} title={title} />}
-            {video?.url && <VideoSlide video={video} playing={playing} />}
+            {video?.url && (
+              <VideoSlide
+                video={video}
+                playing={playing}
+                onVideoEnd={() => {
+                  swiperInstance?.slideNext();
+                  swiperInstance?.autoplay?.start();
+                }}
+              />
+            )}
           </>
         ) : (
           <>

--- a/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
@@ -7,9 +7,10 @@ interface IVideoSlide {
   // setting playing to false will reset the playback position
   // in order to make sure it will always start at its start.
   playing: boolean;
+  onVideoEnd(): void;
 }
 
-const VideoSlide: FC<IVideoSlide> = ({ video, playing }) => {
+const VideoSlide: FC<IVideoSlide> = ({ video, playing, onVideoEnd }) => {
   const videoElementRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -35,6 +36,9 @@ const VideoSlide: FC<IVideoSlide> = ({ video, playing }) => {
       playsInline
       preload="auto"
       className={styles.video}
+      onEnded={() => {
+        onVideoEnd();
+      }}
     />
   );
 };

--- a/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useRef, useEffect } from "react";
+import SwiperCore from "swiper";
 import styles from "./Slide.module.css";
+import { IStopAutoplayResume } from "../../hooks/useAutoplayResume";
 
 interface IVideoSlide {
   video: IVideoOptions;
@@ -7,10 +9,16 @@ interface IVideoSlide {
   // setting playing to false will reset the playback position
   // in order to make sure it will always start at its start.
   playing: boolean;
-  onVideoEnd(): void;
+  swiperInstance: SwiperCore | null;
+  stopAutoplayResume: IStopAutoplayResume;
 }
 
-const VideoSlide: FC<IVideoSlide> = ({ video, playing, onVideoEnd }) => {
+const VideoSlide: FC<IVideoSlide> = ({
+  video,
+  playing,
+  swiperInstance,
+  stopAutoplayResume,
+}) => {
   const videoElementRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -18,12 +26,14 @@ const VideoSlide: FC<IVideoSlide> = ({ video, playing, onVideoEnd }) => {
     if (videoEl) {
       if (playing) {
         videoEl.play();
+        swiperInstance?.autoplay?.stop();
+        stopAutoplayResume();
       } else {
         videoEl.currentTime = 0;
         videoEl.pause();
       }
     }
-  }, [playing]);
+  }, [playing, stopAutoplayResume, swiperInstance?.autoplay]);
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
@@ -37,7 +47,8 @@ const VideoSlide: FC<IVideoSlide> = ({ video, playing, onVideoEnd }) => {
       preload="auto"
       className={styles.video}
       onEnded={() => {
-        onVideoEnd();
+        swiperInstance?.slideNext();
+        swiperInstance?.autoplay?.start();
       }}
     />
   );

--- a/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
+++ b/frontend/src/UI/FullScreenCarousel/VideoSlide.tsx
@@ -33,7 +33,7 @@ const VideoSlide: FC<IVideoSlide> = ({
         videoEl.pause();
       }
     }
-  }, [playing, stopAutoplayResume, swiperInstance?.autoplay]);
+  }, [playing, stopAutoplayResume, swiperInstance]);
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption

--- a/frontend/src/hooks/useAutoplayResume.ts
+++ b/frontend/src/hooks/useAutoplayResume.ts
@@ -5,7 +5,7 @@ interface IStartAutoplayResume {
   (swiperState: SwiperCore): void;
 }
 
-interface IStopAutoplayResume {
+export interface IStopAutoplayResume {
   (): void;
 }
 

--- a/frontend/src/hooks/useAutoplayResume.ts
+++ b/frontend/src/hooks/useAutoplayResume.ts
@@ -27,9 +27,7 @@ const useAutoplayResume: IUseAutoplayResume = (timeout) => {
     stopAutoplayResume();
 
     autoplayTimeout.current = window.setTimeout(() => {
-      if (swiperState && swiperState.autoplay) {
-        swiperState.autoplay.start();
-      }
+      swiperState?.autoplay?.start();
     }, timeout);
   };
 


### PR DESCRIPTION
Works on my machine:tm: 

The way this works is once a video slide is active, bot autoplay and autoplayresume is deactivated and started once the video has finished playing.